### PR TITLE
Add National Iranian Congress TV stream link

### DIFF
--- a/ir2.m3u
+++ b/ir2.m3u
@@ -455,3 +455,5 @@ https://lenz.splus.ir/PLTV/88888888/224/3221227023/index.m3u8
 https://hls.yourtime.live/hls/stream.m3u8
 #EXTINF:-1 tvg-id="ZagrosTV.ir" tvg-logo="https://upload.wikimedia.org/wikipedia/fa/thumb/e/e4/Kermanshah_Zaghros.svg/240px-Kermanshah_Zaghros.svg.png" group-title="General",Zagros
 https://ncdn.telewebion.com/zagros/live/playlist.m3u8
+#EXTINF:-1 tvg-id="NationalIranianCongressTV.ir@SD",National Iranian Congress TV
+https://tv.iraniancongress.com/stream/tv.m3u8


### PR DESCRIPTION
Channel Name: National Iranian Congress TV
Country: Iran 
Category: News
Language: Persian
Stream URL: https://tv.iraniancongress.com/stream/tv.m3u8
**Logo URL: https://iraniancongress.com/tv/logo.png